### PR TITLE
CLOUD-14881 【dev47.35】网页插件设置了广告栏设置为文本：访客端查看广告消息，实际结果：广告消息上部有空白框

### DIFF
--- a/src/js/app/index.js
+++ b/src/js/app/index.js
@@ -278,6 +278,10 @@ function handleCfgData(relevanceList, status){
 	renderUI(status);
 }
 function renderUI(resultStatus){
+	// 添加移动端样式类
+	if(utils.isMobile){
+		utils.addClass(document.body, "em-mobile");
+	}
 	// 用于预览模式
 	if(commonConfig.getConfig().previewObj){
 		handleConfig(commonConfig.getConfig().previewObj);
@@ -285,11 +289,7 @@ function renderUI(resultStatus){
 		main.initChat();
 	}
 	else if(commonConfig.getConfig().configId){
-		// 添加移动端样式类
-		if(utils.isMobile){
-			utils.addClass(document.body, "em-mobile");
-		}
-		else{
+		if(!utils.isMobile){
 			utils.addClass(document.body, "big-window");
 		}
 		// 全部渲染
@@ -309,6 +309,7 @@ function renderUI(resultStatus){
 			functionView.init({
 				resultStatus: resultStatus
 			});
+			main.close();
 		}
 	}
 	else{

--- a/src/scss/body.scss
+++ b/src/scss/body.scss
@@ -281,7 +281,7 @@ body.big-window{
 .em-widget-tip {
 	display: none;
 	position: absolute;
-	top: 41px;
+	top: 0;
 	width: 100%;
 	height: 48px;
 	color: #535252;
@@ -345,7 +345,7 @@ body.big-window{
 .em-widget-wrapper.has-tip {
 	/* 有信息栏时 消息窗 下移 */
 	.chat-wrapper {
-		top: 89px;
+		top: 48px;
 	}
 	/* 显示信息栏 */
 	.em-widget-tip {

--- a/src/scss/ui.scss
+++ b/src/scss/ui.scss
@@ -457,7 +457,7 @@
 	&.off-duty-prompt {
 		width: 300px;
 		height: 190px;
-		position: fixed;
+		position: absolute;
 		top: 0;
 		bottom: 0;
 		left: 0;
@@ -653,11 +653,11 @@
 }
 
 .em-model {
-    position: fixed;
+    position: absolute;
     width: 100%;
     filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=30);
     background-color: rgba(0,0,0,.3);
-    top: 40px;
+    top: 0;
     bottom: 0;
     z-index: 999;
 }


### PR DESCRIPTION
CLOUD-14871 【dev47.35】手机端打开网页插件，输入框的高度不正确，需要调整
CLOUD-14864 【dev47.35】网页插件设置了广告栏设置，访客端查看，实际结果：自定义导航菜单的样式需要调整
CLOUD-14745 【dev47.35】使用bind函数按钮集成方式，配置configId并点击按钮打开聊天窗口，点击右上角【最小化窗口】的按钮，再一次点击bind所在的按钮，发现聊天窗口白屏